### PR TITLE
Allow opam 2.3.

### DIFF
--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -186,6 +186,7 @@ module Package_flag = struct
     | Pkgflag_Conf -> Fmt.pf pps "conf"
     | Pkgflag_AvoidVersion -> Fmt.pf pps "avoid-version"
     | Pkgflag_Unknown unknown -> Fmt.pf pps "unknown(%s)" unknown
+    | Pkgflag_Deprecated -> Fmt.pf pps "deperecated"
 end
 
 module Package_summary = struct

--- a/opam-monorepo.opam
+++ b/opam-monorepo.opam
@@ -24,7 +24,7 @@ depends: [
   "logs"
   "opam-file-format" {>= "2.1.0"}
   "opam-format" {>= "2.1.0~rc2"}
-  "opam-state" {>= "2.1.0~rc2" & < "2.2.0"}
+  "opam-state" {>= "2.1.0~rc2" & < "2.4.0"}
   "opam-0install"
   "ocaml-version"
   "sexplib"


### PR DESCRIPTION
Dear @hannesm , now I'm also having issues with opam-monorepo, and I have opam 2.3, so I've updated your branch to allow this version (I think the config part of the patch should work with earlier versions of opam as that was an unused parameter, but I'm not sure how the new flag will behave, and I hope it will be good, otherwise I'll need to increase the lower bound too).
Please let me know if anything needs to be changed :)
Best.